### PR TITLE
feat: implementar páginas de Perfil e Configurações - Issue #5

### DIFF
--- a/src/__tests__/AuthProvider.test.tsx
+++ b/src/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider, useAuth } from '../components/common/AuthProvider'
+
+vi.mock('../api/auth.api', () => ({
+  authApi: {
+    getProfile: vi.fn().mockRejectedValue(new Error('not authenticated')),
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    updateProfile: vi.fn(),
+    changePassword: vi.fn(),
+    refreshToken: vi.fn(),
+  },
+  getCurrentUser: vi.fn().mockReturnValue(null),
+  clearUserData: vi.fn(),
+  setUserData: vi.fn(),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+const TestConsumer = () => {
+  const auth = useAuth()
+  return (
+    <div>
+      <span data-testid="has-change-password">{typeof auth.changePassword}</span>
+    </div>
+  )
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('exposes changePassword function in context', async () => {
+    const Wrapper = createWrapper()
+    await act(async () => {
+      render(
+        <Wrapper>
+          <TestConsumer />
+        </Wrapper>
+      )
+    })
+    expect(screen.getByTestId('has-change-password').textContent).toBe('function')
+  })
+
+  it('calls authApi.changePassword with correct args', async () => {
+    const { authApi } = await import('../api/auth.api')
+    const mockChangePassword = vi.fn().mockResolvedValue({ data: {} })
+    vi.mocked(authApi.changePassword).mockImplementation(mockChangePassword)
+
+    const Wrapper = createWrapper()
+    let changePasswordFn: ((data: { currentPassword: string; newPassword: string }) => Promise<void>) | undefined
+
+    const Capture = () => {
+      const auth = useAuth()
+      changePasswordFn = auth.changePassword
+      return null
+    }
+
+    await act(async () => {
+      render(
+        <Wrapper>
+          <Capture />
+        </Wrapper>
+      )
+    })
+
+    await act(async () => {
+      await changePasswordFn!({ currentPassword: 'old123', newPassword: 'new456' })
+    })
+
+    expect(mockChangePassword).toHaveBeenCalledWith({
+      currentPassword: 'old123',
+      newPassword: 'new456',
+    })
+  })
+})

--- a/src/__tests__/Profile.test.tsx
+++ b/src/__tests__/Profile.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { vi, describe, it, expect } from 'vitest'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import Profile from '../pages/Profile/Profile'
+
+const mockUser = {
+  id: '1',
+  email: 'test@test.com',
+  username: 'testuser',
+  firstName: 'João',
+  lastName: 'Silva',
+  bio: 'Corredor amador',
+  country: 'Brasil',
+  city: 'São Paulo',
+  isActive: true,
+  role: 'user' as const,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  totalRaces: 10,
+  totalDistance: 150.5,
+  wins: 2,
+  personalBest5k: 1500,
+  personalBest10k: 3200,
+  personalBestHalfMarathon: 7200,
+  personalBestMarathon: 15600,
+  isVerified: true,
+}
+
+vi.mock('../components/common/AuthProvider', () => ({
+  useAuth: () => ({ user: mockUser }),
+}))
+
+const renderProfile = () =>
+  render(
+    <MemoryRouter>
+      <Profile />
+    </MemoryRouter>
+  )
+
+describe('Profile page', () => {
+  it('renders user full name and username', () => {
+    renderProfile()
+    expect(screen.getByText('João Silva')).toBeTruthy()
+    expect(screen.getByText('@testuser')).toBeTruthy()
+  })
+
+  it('renders user bio', () => {
+    renderProfile()
+    expect(screen.getByText('Corredor amador')).toBeTruthy()
+  })
+
+  it('renders stats section with totalRaces, totalDistance and wins', () => {
+    renderProfile()
+    expect(screen.getByText('10')).toBeTruthy()
+    expect(screen.getByText('2')).toBeTruthy()
+  })
+
+  it('renders Edit Profile link pointing to /settings', () => {
+    renderProfile()
+    const link = screen.getByRole('link', { name: /editar perfil/i })
+    expect(link.getAttribute('href')).toBe('/settings')
+  })
+})

--- a/src/__tests__/Settings.test.tsx
+++ b/src/__tests__/Settings.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import Settings from '../pages/Settings/Settings'
+
+const mockUser = {
+  id: '1',
+  email: 'test@test.com',
+  username: 'testuser',
+  firstName: 'João',
+  lastName: 'Silva',
+  bio: 'Corredor',
+  country: 'Brasil',
+  city: 'SP',
+  isActive: true,
+  role: 'user' as const,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+}
+
+vi.mock('../components/common/AuthProvider', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    updateProfile: vi.fn(),
+    changePassword: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/common/ThemeProvider', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    toggleTheme: vi.fn(),
+  }),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+const renderSettings = () =>
+  render(
+    <MemoryRouter>
+      <Settings />
+    </MemoryRouter>
+  )
+
+describe('Settings page', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe('Perfil tab', () => {
+    it('renders profile form fields by default', () => {
+      renderSettings()
+      expect(screen.getByLabelText(/primeiro nome/i)).toBeTruthy()
+      expect(screen.getByLabelText(/sobrenome/i)).toBeTruthy()
+      expect(screen.getByLabelText(/username/i)).toBeTruthy()
+      expect(screen.getByLabelText(/bio/i)).toBeTruthy()
+    })
+  })
+
+  describe('Segurança tab', () => {
+    it('renders password fields when Segurança tab is clicked', () => {
+      renderSettings()
+      fireEvent.click(screen.getByRole('button', { name: /segurança/i }))
+      expect(screen.getByLabelText('Senha Atual')).toBeTruthy()
+      expect(screen.getByLabelText('Nova Senha')).toBeTruthy()
+      expect(screen.getByLabelText('Confirmar Nova Senha')).toBeTruthy()
+    })
+  })
+
+  describe('Aparência tab', () => {
+    it('renders theme toggle when Aparência tab is clicked', () => {
+      renderSettings()
+      fireEvent.click(screen.getByRole('button', { name: /aparência/i }))
+      expect(screen.getByText(/modo escuro/i)).toBeTruthy()
+    })
+  })
+})

--- a/src/components/common/AuthProvider.tsx
+++ b/src/components/common/AuthProvider.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
   register: (data: any) => Promise<void>
   logout: () => Promise<void>
   updateProfile: (data: any) => Promise<void>
+  changePassword: (data: { currentPassword: string; newPassword: string }) => Promise<void>
   refreshUser: () => Promise<void>
 }
 
@@ -113,6 +114,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   }
 
+  const changePassword = async (data: { currentPassword: string; newPassword: string }) => {
+    try {
+      await authApi.changePassword(data)
+      toast.success('Senha alterada com sucesso!')
+    } catch (error) {
+      toast.error('Erro ao alterar senha.')
+      throw error
+    }
+  }
+
   const refreshUser = async () => {
     await refetch()
   }
@@ -164,6 +175,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     register,
     logout,
     updateProfile,
+    changePassword,
     refreshUser,
   }
 

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { MapPin, Trophy, Activity, Clock, Settings, Award } from 'lucide-react'
+import { useAuth } from '../../components/common/AuthProvider'
+
+const formatTime = (seconds: number | null | undefined): string => {
+  if (!seconds) return '—'
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = seconds % 60
+  if (h > 0) return `${h}h ${m}m ${s}s`
+  return `${m}m ${s}s`
+}
+
+const formatDistance = (km: number): string => {
+  return km >= 1000 ? `${(km / 1000).toFixed(1)}k km` : `${km.toFixed(1)} km`
+}
+
+const Profile: React.FC = () => {
+  const { user } = useAuth()
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-gray-500 dark:text-gray-400">Usuário não encontrado.</p>
+      </div>
+    )
+  }
+
+  const initials = [user.firstName, user.lastName]
+    .filter(Boolean)
+    .map((n) => n![0].toUpperCase())
+    .join('') || user.username[0].toUpperCase()
+
+  const location = [user.city, user.country].filter(Boolean).join(', ')
+
+  const personalBests = [
+    { label: '5km', value: (user as any).personalBest5k },
+    { label: '10km', value: (user as any).personalBest10k },
+    { label: 'Meia Maratona', value: (user as any).personalBestHalfMarathon },
+    { label: 'Maratona', value: (user as any).personalBestMarathon },
+  ]
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {/* Header Card */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex flex-col sm:flex-row items-center sm:items-start gap-5">
+          {/* Avatar */}
+          <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center flex-shrink-0">
+            <span className="text-white text-2xl font-bold">{initials}</span>
+          </div>
+
+          {/* Info */}
+          <div className="flex-1 text-center sm:text-left">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              {[user.firstName, user.lastName].filter(Boolean).join(' ') || user.username}
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400 text-sm mt-0.5">@{user.username}</p>
+
+            {location && (
+              <div className="flex items-center justify-center sm:justify-start gap-1 mt-2 text-sm text-gray-500 dark:text-gray-400">
+                <MapPin size={14} />
+                <span>{location}</span>
+              </div>
+            )}
+
+            {user.bio && (
+              <p className="mt-3 text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+                {user.bio}
+              </p>
+            )}
+          </div>
+
+          {/* Edit button */}
+          <Link
+            to="/settings"
+            aria-label="Editar Perfil"
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+          >
+            <Settings size={15} />
+            Editar Perfil
+          </Link>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+          <Activity size={18} className="text-blue-500" />
+          Estatísticas
+        </h2>
+        <div className="grid grid-cols-3 gap-4">
+          <div className="text-center">
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {(user as any).totalRaces ?? 0}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Corridas</p>
+          </div>
+          <div className="text-center">
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {formatDistance((user as any).totalDistance ?? 0)}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Distância Total</p>
+          </div>
+          <div className="text-center">
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {(user as any).wins ?? 0}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Vitórias</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Personal Bests */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+          <Trophy size={18} className="text-yellow-500" />
+          Melhores Tempos Pessoais
+        </h2>
+        <div className="grid grid-cols-2 gap-3">
+          {personalBests.map(({ label, value }) => (
+            <div
+              key={label}
+              className="flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-700/50 rounded-xl"
+            >
+              <div className="flex items-center gap-2">
+                <Clock size={14} className="text-gray-400" />
+                <span className="text-sm text-gray-600 dark:text-gray-300">{label}</span>
+              </div>
+              <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                {formatTime(value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Achievements placeholder */}
+      {(user as any).isVerified && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+            <Award size={18} className="text-purple-500" />
+            Conquistas
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Conta verificada ✓
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Profile

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,0 +1,331 @@
+import React, { useState } from 'react'
+import { User, Lock, Palette, Sun, Moon, Save, Eye, EyeOff } from 'lucide-react'
+import { useAuth } from '../../components/common/AuthProvider'
+import { useTheme } from '../../components/common/ThemeProvider'
+
+type Tab = 'profile' | 'security' | 'appearance'
+
+const Settings: React.FC = () => {
+  const { user, updateProfile, changePassword } = useAuth()
+  const { theme, toggleTheme } = useTheme()
+
+  const [activeTab, setActiveTab] = useState<Tab>('profile')
+
+  // Profile form state
+  const [profileForm, setProfileForm] = useState({
+    firstName: user?.firstName || '',
+    lastName: user?.lastName || '',
+    username: user?.username || '',
+    bio: user?.bio || '',
+    country: user?.country || '',
+    city: user?.city || '',
+    birthDate: (user as any)?.birthDate?.toString().split('T')[0] || '',
+  })
+  const [profileLoading, setProfileLoading] = useState(false)
+
+  // Password form state
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmNewPassword: '',
+  })
+  const [passwordLoading, setPasswordLoading] = useState(false)
+  const [showCurrent, setShowCurrent] = useState(false)
+  const [showNew, setShowNew] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [passwordError, setPasswordError] = useState('')
+
+  const handleProfileSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setProfileLoading(true)
+    try {
+      await updateProfile(profileForm)
+    } finally {
+      setProfileLoading(false)
+    }
+  }
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setPasswordError('')
+
+    if (passwordForm.newPassword !== passwordForm.confirmNewPassword) {
+      setPasswordError('As novas senhas não coincidem.')
+      return
+    }
+
+    setPasswordLoading(true)
+    try {
+      await changePassword({
+        currentPassword: passwordForm.currentPassword,
+        newPassword: passwordForm.newPassword,
+      })
+      setPasswordForm({ currentPassword: '', newPassword: '', confirmNewPassword: '' })
+    } finally {
+      setPasswordLoading(false)
+    }
+  }
+
+  const tabs = [
+    { id: 'profile' as Tab, label: 'Perfil', icon: User },
+    { id: 'security' as Tab, label: 'Segurança', icon: Lock },
+    { id: 'appearance' as Tab, label: 'Aparência', icon: Palette },
+  ]
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Configurações</h1>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
+        {tabs.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            onClick={() => setActiveTab(id)}
+            className={`flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+              activeTab === id
+                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+            }`}
+          >
+            <Icon size={15} />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Profile Tab */}
+      {activeTab === 'profile' && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-5">Informações do Perfil</h2>
+          <form onSubmit={handleProfileSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="firstName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Primeiro Nome
+                </label>
+                <input
+                  id="firstName"
+                  type="text"
+                  value={profileForm.firstName}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, firstName: e.target.value }))}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label htmlFor="lastName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Sobrenome
+                </label>
+                <input
+                  id="lastName"
+                  type="text"
+                  value={profileForm.lastName}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, lastName: e.target.value }))}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="username" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Username
+              </label>
+              <input
+                id="username"
+                type="text"
+                value={profileForm.username}
+                onChange={(e) => setProfileForm((p) => ({ ...p, username: e.target.value }))}
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="bio" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Bio
+              </label>
+              <textarea
+                id="bio"
+                rows={3}
+                value={profileForm.bio}
+                onChange={(e) => setProfileForm((p) => ({ ...p, bio: e.target.value }))}
+                maxLength={500}
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+              <p className="text-xs text-gray-400 mt-1 text-right">{profileForm.bio.length}/500</p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="country" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  País
+                </label>
+                <input
+                  id="country"
+                  type="text"
+                  value={profileForm.country}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, country: e.target.value }))}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label htmlFor="city" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Cidade
+                </label>
+                <input
+                  id="city"
+                  type="text"
+                  value={profileForm.city}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, city: e.target.value }))}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="birthDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Data de Nascimento
+              </label>
+              <input
+                id="birthDate"
+                type="date"
+                value={profileForm.birthDate}
+                onChange={(e) => setProfileForm((p) => ({ ...p, birthDate: e.target.value }))}
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div className="flex justify-end pt-2">
+              <button
+                type="submit"
+                disabled={profileLoading}
+                className="flex items-center gap-2 px-5 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                <Save size={15} />
+                {profileLoading ? 'Salvando...' : 'Salvar Alterações'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Security Tab */}
+      {activeTab === 'security' && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-5">Alterar Senha</h2>
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="currentPassword" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Senha Atual
+              </label>
+              <div className="relative">
+                <input
+                  id="currentPassword"
+                  type={showCurrent ? 'text' : 'password'}
+                  value={passwordForm.currentPassword}
+                  onChange={(e) => setPasswordForm((p) => ({ ...p, currentPassword: e.target.value }))}
+                  required
+                  className="w-full px-3 py-2 pr-10 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => setShowCurrent((v) => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                  {showCurrent ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Nova Senha
+              </label>
+              <div className="relative">
+                <input
+                  id="newPassword"
+                  type={showNew ? 'text' : 'password'}
+                  value={passwordForm.newPassword}
+                  onChange={(e) => setPasswordForm((p) => ({ ...p, newPassword: e.target.value }))}
+                  required
+                  className="w-full px-3 py-2 pr-10 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => setShowNew((v) => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                  {showNew ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="confirmNewPassword" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Confirmar Nova Senha
+              </label>
+              <div className="relative">
+                <input
+                  id="confirmNewPassword"
+                  type={showConfirm ? 'text' : 'password'}
+                  value={passwordForm.confirmNewPassword}
+                  onChange={(e) => setPasswordForm((p) => ({ ...p, confirmNewPassword: e.target.value }))}
+                  required
+                  className="w-full px-3 py-2 pr-10 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => setShowConfirm((v) => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                  {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+            </div>
+
+            {passwordError && (
+              <p className="text-sm text-red-500">{passwordError}</p>
+            )}
+
+            <div className="flex justify-end pt-2">
+              <button
+                type="submit"
+                disabled={passwordLoading}
+                className="flex items-center gap-2 px-5 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                <Lock size={15} />
+                {passwordLoading ? 'Alterando...' : 'Alterar Senha'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Appearance Tab */}
+      {activeTab === 'appearance' && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-5">Aparência</h2>
+
+          <div className="flex items-center justify-between py-3 border-b border-gray-100 dark:border-gray-700">
+            <div className="flex items-center gap-3">
+              {theme === 'dark' ? (
+                <Moon size={20} className="text-indigo-400" />
+              ) : (
+                <Sun size={20} className="text-yellow-500" />
+              )}
+              <div>
+                <p className="text-sm font-medium text-gray-900 dark:text-white">Modo Escuro</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {theme === 'dark' ? 'Ativado' : 'Desativado'}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={toggleTheme}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                theme === 'dark' ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+              }`}
+              role="switch"
+              aria-checked={theme === 'dark'}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  theme === 'dark' ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Settings


### PR DESCRIPTION
## Resumo

Implementa as páginas `/profile` e `/settings` que já tinham rotas definidas no `App.tsx` mas não possuíam componentes. Adiciona `changePassword` ao contexto do `AuthProvider`.

## O que foi feito

### `AuthProvider`
- Exposto `changePassword` no contexto com tratamento de erro e toast

### Profile (`src/pages/Profile/Profile.tsx`)
- Avatar com iniciais geradas do nome
- Nome completo, username, bio e localização (cidade + país)
- Seção de estatísticas: total de corridas, distância total, vitórias
- Seção de melhores tempos pessoais (5k, 10k, meia-maratona, maratona) com formatação `Xm Ys`
- Botão "Editar Perfil" linkando para `/settings`

### Settings (`src/pages/Settings/Settings.tsx`)
- Tab **Perfil**: formulário com firstName, lastName, username, bio, country, city, birthDate
- Tab **Segurança**: formulário de troca de senha com validação de confirmação e toggle de visibilidade
- Tab **Aparência**: toggle dark/light mode via `useTheme`

### Testes
- 9 testes unitários cobrindo todos os comportamentos implementados

## Critérios de Aceitação

- [x] Página `/profile` exibe os dados do usuário autenticado
- [x] Página `/settings` permite editar o perfil com feedback de sucesso/erro
- [x] Troca de senha funciona com validação de confirmação
- [x] Toggle de tema funciona sem reload
- [x] Testes unitários cobrem os componentes principais (9/9 passando)

Closes #5