### PR TITLE
fix: corrigir fluxo de registro e login - Issue #7

### DIFF
--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { registerSchema, usernameSchema } from '../utils/validators'
+
+describe('usernameSchema', () => {
+  it('accepts valid username with letters, numbers and underscore', () => {
+    expect(usernameSchema.safeParse('joao_silva123').success).toBe(true)
+  })
+
+  it('rejects username with dot', () => {
+    expect(usernameSchema.safeParse('joao.silva').success).toBe(false)
+  })
+
+  it('rejects username with hyphen', () => {
+    expect(usernameSchema.safeParse('joao-silva').success).toBe(false)
+  })
+})
+
+describe('registerSchema', () => {
+  const validBase = {
+    email: 'test@example.com',
+    password: 'Password1',
+    firstName: 'João',
+    lastName: 'Silva',
+    username: 'joaosilva',
+  }
+
+  it('accepts valid data when confirmPassword matches password', () => {
+    const result = registerSchema.safeParse({
+      ...validBase,
+      confirmPassword: 'Password1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects when confirmPassword differs from password', () => {
+    const result = registerSchema.safeParse({
+      ...validBase,
+      confirmPassword: 'DifferentPass1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects when confirmPassword is missing', () => {
+    const result = registerSchema.safeParse(validBase)
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -22,6 +22,7 @@ const Register: React.FC = () => {
     defaultValues: {
       email: '',
       password: '',
+      confirmPassword: '',
       firstName: '',
       lastName: '',
       username: '',
@@ -187,7 +188,7 @@ const Register: React.FC = () => {
                 </p>
               )}
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Pode conter letras, números, pontos, underscores e hífens
+                Pode conter apenas letras, números e underscores
               </p>
             </div>
 
@@ -298,6 +299,25 @@ const Register: React.FC = () => {
                   </li>
                 </ul>
               </div>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="confirmPassword" className="label">
+                Confirmar Senha
+              </label>
+              <input
+                id="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                className={`input ${errors.confirmPassword ? 'input-error' : ''}`}
+                placeholder="••••••••"
+                {...register('confirmPassword')}
+              />
+              {errors.confirmPassword && (
+                <p className="mt-1 text-sm text-danger-600 dark:text-danger-400">
+                  {errors.confirmPassword.message}
+                </p>
+              )}
             </div>
 
             <div className="form-group">

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -61,6 +61,7 @@ export interface LoginRequest {
 export interface RegisterRequest {
   email: string
   password: string
+  confirmPassword: string
   firstName: string
   lastName: string
   username: string

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -16,7 +16,7 @@ export const usernameSchema = z
   .string()
   .min(3, 'Username deve ter pelo menos 3 caracteres')
   .max(30, 'Username não pode exceder 30 caracteres')
-  .regex(/^[a-zA-Z0-9_.-]+$/, 'Username pode conter apenas letras, números, pontos, underscores e hífens')
+  .regex(/^[a-zA-Z0-9_]+$/, 'Username pode conter apenas letras, números e underscores')
 
 export const nameSchema = z
   .string()
@@ -49,12 +49,16 @@ export const loginSchema = z.object({
 export const registerSchema = z.object({
   email: emailSchema,
   password: passwordSchema,
+  confirmPassword: z.string().min(1, 'Confirmação de senha é obrigatória'),
   firstName: nameSchema,
   lastName: nameSchema,
   username: usernameSchema,
   birthDate: birthDateSchema,
   country: z.string().max(100, 'País não pode exceder 100 caracteres').optional(),
   city: z.string().max(100, 'Cidade não pode exceder 100 caracteres').optional(),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: 'As senhas não coincidem',
+  path: ['confirmPassword'],
 })
 
 // Race creation validation schema


### PR DESCRIPTION
## Resumo

Corrige dois bugs críticos que impediam o fluxo de registro de funcionar:

1. **`confirmPassword` ausente** — o backend exige o campo, mas o formulário não enviava, causando `VALIDATION_ERROR` em toda tentativa de cadastro
2. **Regex de username incompatível** — frontend aceitava `.` e `-`, mas o backend rejeitava

## O que foi feito

- `RegisterRequest` type: adicionado `confirmPassword: string`
- `registerSchema` (validators.ts): adicionado `confirmPassword` com validação `password === confirmPassword`
- `usernameSchema` (validators.ts): regex corrigido de `/^[a-zA-Z0-9_.-]+$/` para `/^[a-zA-Z0-9_]+$/`
- `Register.tsx`: adicionado campo "Confirmar Senha" após o campo de senha; hint de username atualizado
- 6 testes unitários cobrindo todos os comportamentos

## Critérios de Aceitação

- [x] Registro funciona end-to-end sem erros de validação
- [x] Campo "Confirmar Senha" exibe erro quando senhas não coincidem
- [x] Username com `.` ou `-` é rejeitado no frontend
- [x] 6/6 testes passando, sem regressões

Closes #7